### PR TITLE
Fix php checks

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -114,9 +114,11 @@ function checkPHP () {
 }
 
 function installPHP () {
-    echo "Installing PHP..."
+    echo "Installing PHP 5.6..."
+    # add php repo, because since ubuntu 16.4 php 5.6 is no longer standard
+    sudo add-apt-repository ppa:ondrej/php
     sudo apt-get update
-    sudo apt-get install php5 libapache2-mod-php5 php5-mcrypt
+    sudo apt-get install php5.6 libapache2-mod-php5.6 php5.6-mcrypt
     INSTALL_PHP=0
     checkPHP 1
 }

--- a/check.sh
+++ b/check.sh
@@ -106,7 +106,6 @@ function checkPHP () {
         PHP_VERSION=$(php -r \@phpinfo\(\)\; | grep 'PHP Version' -m 1 | grep -o [[:digit:]]\.[[:digit:]]\.[[:digit:]] -m 1)
         checkVersion $PHP_VERSION $REQUIRED_PHP_VERSION "PHP"
         checkPDO
-        checkPHPModule "apc"
         checkPHPModule "intl"
     fi
     # if PHP is not installed, but we tried to install it, we inform the user, that the installation failed

--- a/check.sh
+++ b/check.sh
@@ -141,7 +141,8 @@ function checkMySQL () {
 function installMySQL () {
     echo "Installing MySQL..."
     sudo apt-get update
-    sudo apt-get install mysql-server libapache2-mod-auth-mysql php5-mysql
+    sudo apt-get install mysql-server
+    installPHPModule mysql
     sudo mysql_install_db
     sudo /usr/bin/mysql_secure_installation
     INSTALL_MYSQL=0


### PR DESCRIPTION
Fix #1 
Added functionality to check php modules easier.
Change php to php5.6 instead of newest 5.x.
Remove APC testing because it is no longer used.