### PR TITLE
Php8

### DIFF
--- a/Docker/PHP8.0-with-mysql/Dockerfile
+++ b/Docker/PHP8.0-with-mysql/Dockerfile
@@ -1,0 +1,4 @@
+FROM cloudrexx/web:PHP8.0
+RUN bash -c "apt update && apt install -y \
+    # Ubuntu packages
+        mariadb-client"

--- a/Docker/PHP8.0/Dockerfile
+++ b/Docker/PHP8.0/Dockerfile
@@ -1,0 +1,50 @@
+FROM php:8.0-rc-apache
+RUN bash -c "apt update"
+RUN bash -c "apt install -y \
+    # Ubuntu packages
+        exiftool \
+        libmemcached-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libsodium-dev \
+        libpng-dev \
+        libicu-dev \
+        zlib1g-dev \
+        libzip-dev \
+        msmtp \
+        ssl-cert"
+    # PHP extensions
+RUN bash -c "curl -L https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar > pickle.phar && chmod +x pickle.phar && mv pickle.phar /usr/local/bin/pickle \
+        && docker-php-ext-configure exif && docker-php-ext-install exif && docker-php-ext-enable exif \
+        && docker-php-ext-configure gd && docker-php-ext-install -j$(nproc) gd \
+        && docker-php-ext-install -j$(nproc) iconv opcache mysqli pdo_mysql intl bcmath zip sodium \
+        && pickle install memcached && echo extension=memcached.so >> /usr/local/etc/php/conf.d/memcached.ini \
+    # PHP configuration
+        && echo 'date.timezone = \"UTC\"' >> /usr/local/etc/php/php.ini \
+        && echo 'default_socket_timeout = 600' >> /usr/local/etc/php/php.ini \
+        && echo 'sendmail_path = /usr/sbin/msmtp -t --read-envelope-from' >> /usr/local/etc/php/php.ini \
+    # Apache configuration
+        && a2enmod rewrite \
+        && a2enmod expires \
+        && a2enmod headers \
+        && a2enmod ssl \
+        && echo \"UseCanonicalName On\" >> /etc/apache2/apache2.conf \
+        && ln -s /etc/apache2/sites-available/default-ssl.conf /etc/apache2/sites-enabled/default-ssl.conf \
+    # Cleanup
+        && apt-get autoremove -y \
+        && apt-get remove -y \
+            libfreetype6-dev \
+            libpng-dev \
+            libmemcached-dev \
+            libsodium-dev \
+            libjpeg62-turbo-dev \
+            libicu-dev \
+            zlib1g-dev \
+            libzip-dev \
+        && apt-get clean \
+        && rm -rf /tmp/pear"
+COPY clx-docker-msmtp-config /etc/msmtprc
+COPY clx-docker-php-entrypoint /usr/local/bin/
+EXPOSE 443
+ENTRYPOINT ["clx-docker-php-entrypoint"]
+CMD ["apache2-foreground"]

--- a/Docker/PHP8.0/clx-docker-msmtp-config
+++ b/Docker/PHP8.0/clx-docker-msmtp-config
@@ -1,0 +1,4 @@
+account         mailhog
+host            mail
+
+account default : mailhog

--- a/Docker/PHP8.0/clx-docker-php-entrypoint
+++ b/Docker/PHP8.0/clx-docker-php-entrypoint
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+usermod -u $(stat -c '%u' /var/www/html) www-data
+groupmod -g $(stat -c '%g' /var/www/html) www-data
+
+docker-php-entrypoint "$@"


### PR DESCRIPTION
This pull requests adds support for PHP 8.0 rc for testing. It's currently based on PHP's 8.0-rc-apache image.

This is a modified copy of the 7.4 image.

If this gets approved the relevant packages need to get built and pushed to the docker repository.